### PR TITLE
removes redundant alert reporting

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -267,7 +267,8 @@ class Bot:
 			try:
 				alerts = warframe.alert_analysis()
 				if len(alerts) > 0 and alerts != last_alerts:
-					self.send_message(config.bot.warframe['channel'], '\n'.join(alerts))
+					broadcast_alerts = set(alerts) - set(last_alerts)
+					self.send_message(config.bot.warframe['channel'], '\n'.join(broadcast_alerts))
 				last_alerts = alerts
 			except requests.exceptions.RequestException as e:
 				log.write('warframe: %s' % e)


### PR DESCRIPTION
checks prior alert list with new alert list and removes any overlap to only report new alerts to cut down on duplicate reporting when alerts cycle in/out