### PR TITLE
acnh: fix typos, usernames with spaces, times sorted lexicographically

### DIFF
--- a/acnh.sql
+++ b/acnh.sql
@@ -13,6 +13,9 @@ CREATE TABLE IF NOT EXISTS sell_price (
 	FOREIGN KEY(user_id) REFERENCES user(id)
 );
 
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sell_price_user_expiration
+ON sell_price (user_id, expiration);
+
 CREATE TABLE IF NOT EXISTS sell_trigger (
 	user_id TEXT PRIMARY KEY,
 	price INTEGER,

--- a/friend_code.py
+++ b/friend_code.py
@@ -25,7 +25,7 @@ def friend_code(cmd):
 	elif subcmd == 'remove':
 		_user_remove(cmd)
 	else:
-		_user_find(cmd, split[0])
+		_user_find(cmd, cmd.args)
 
 def _user_upsert_friend_code(cmd, split):
 	if len(split) != 2:


### PR DESCRIPTION
sorry I let these typos slide in. Also adjusted my query to not use caching and instead just use `expiration > current_time`. I knew that iso dates could be sorted lexicographically, I dunno why I implemented it like that initially. I also fixed `!fc` so if it doesn't get a recognized subcommand it just passes through all of the args to search on rather than just the split subarg.