### PR TITLE
Fix wttr.in glitch regarding passing flags in filename

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -108,9 +108,8 @@ def weather(cmd):
 	else:
 		flags = '1Fp'
 		location = cmd.args
-	filename = '%s.png?%s' % (urllib.parse.quote_plus(location), flags)
-	url = 'https://wttr.in/' + filename
-	try:
+	url = 'https://wttr.in/%s.png?%s' % (urllib.parse.quote_plus(location), flags)
+        try:
 		response = rs.get(url)
 		response.raise_for_status()
 	except Exception:

--- a/utils.py
+++ b/utils.py
@@ -116,7 +116,7 @@ def weather(cmd):
 		cmd.reply('%s: error getting weather at %s' % (cmd.sender['username'], url),
 				{'description': '```%s```' % traceback.format_exc()[-500:]})
 		return
-	cmd.reply(None, files={filename: response.content})
+	cmd.reply(None, files={'weather.png': response.content})
 
 def ohno(cmd):
 	url = 'https://www.raylu.net/f/ohno/ohno%03d.png' % random.randint(1, 294)

--- a/utils.py
+++ b/utils.py
@@ -108,7 +108,7 @@ def weather(cmd):
 	else:
 		flags = '1Fp'
 		location = cmd.args
-	filename = '%s_%s.png' % (urllib.parse.quote_plus(location), flags)
+	filename = '%s.png?%s' % (urllib.parse.quote_plus(location), flags)
 	url = 'https://wttr.in/' + filename
 	try:
 		response = rs.get(url)

--- a/utils.py
+++ b/utils.py
@@ -109,7 +109,7 @@ def weather(cmd):
 		flags = '1Fp'
 		location = cmd.args
 	url = 'https://wttr.in/%s.png?%s' % (urllib.parse.quote_plus(location), flags)
-        try:
+	try:
 		response = rs.get(url)
 		response.raise_for_status()
 	except Exception:


### PR DESCRIPTION
For whatever reason wttr.in ignores the `m` flag (Metric system units)
in the URI format /CITY_flags.png, but not /CITY.png?flags. This commit
changes string formatting in the command to use the latter.